### PR TITLE
Dev branch

### DIFF
--- a/shared/Cargo.lock
+++ b/shared/Cargo.lock
@@ -90,8 +90,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -464,6 +466,7 @@ checksum = "dd6469f4314d5f1ffec476e05f17cc9a78bc7a27a6a857842170bdf8d6f98d2f"
 dependencies = [
  "getrandom",
  "rand",
+ "serde",
  "uuid-macro-internal",
 ]
 

--- a/src-tauri/migration/src/lib.rs
+++ b/src-tauri/migration/src/lib.rs
@@ -1,12 +1,18 @@
 pub use sea_orm_migration::prelude::*;
 
-mod m20220101_000001_create_table;
+mod m20220101_000001_file_tree;
+mod m20220923_134917_file_adjacency;
+mod m20220923_134920_file_node;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20220101_000001_create_table::Migration)]
+        vec![
+            Box::new(m20220101_000001_file_tree::Migration),
+            Box::new(m20220923_134920_file_node::Migration),
+            Box::new(m20220923_134917_file_adjacency::Migration),
+        ]
     }
 }

--- a/src-tauri/migration/src/m20220101_000001_file_tree.rs
+++ b/src-tauri/migration/src/m20220101_000001_file_tree.rs
@@ -1,0 +1,37 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(FileTree::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(FileTree::Id)
+                            .uuid()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(FileTree::Table).to_owned())
+            .await
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+pub enum FileTree {
+    Table,
+    Id,
+}

--- a/src-tauri/migration/src/m20220923_134917_file_adjacency.rs
+++ b/src-tauri/migration/src/m20220923_134917_file_adjacency.rs
@@ -18,24 +18,24 @@ impl MigrationTrait for Migration {
                     .col(ColumnDef::new(FileAdjacency::ChildId).uuid().not_null())
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
-                            .from_tbl(FileTree::Table)
-                            .from_col(FileTree::Id)
-                            .to_tbl(FileAdjacency::Table)
-                            .to_col(FileAdjacency::TreeId),
+                            .from_tbl(FileAdjacency::Table)
+                            .from_col(FileAdjacency::TreeId)
+                            .to_tbl(FileTree::Table)
+                            .to_col(FileTree::Id)
                     )
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
-                            .from_tbl(FileNode::Table)
-                            .from_col(FileNode::Id)
-                            .to_tbl(FileAdjacency::Table)
-                            .to_col(FileAdjacency::ParentId),
+                            .from_tbl(FileAdjacency::Table)
+                            .from_col(FileAdjacency::ParentId)
+                            .to_tbl(FileNode::Table)
+                            .to_col(FileNode::Id)
                     )
                     .foreign_key(
                         ForeignKeyCreateStatement::new()
-                            .from_tbl(FileNode::Table)
-                            .from_col(FileNode::Id)
-                            .to_tbl(FileAdjacency::Table)
-                            .to_col(FileAdjacency::ChildId),
+                            .from_tbl(FileAdjacency::Table)
+                            .from_col(FileAdjacency::ChildId)
+                            .to_tbl(FileNode::Table)
+                            .to_col(FileNode::Id)
                     )
                     .to_owned(),
             )

--- a/src-tauri/migration/src/m20220923_134917_file_adjacency.rs
+++ b/src-tauri/migration/src/m20220923_134917_file_adjacency.rs
@@ -1,0 +1,62 @@
+use crate::m20220101_000001_file_tree::FileTree;
+use crate::m20220923_134920_file_node::FileNode;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(FileAdjacency::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(FileAdjacency::TreeId).uuid().not_null())
+                    .col(ColumnDef::new(FileAdjacency::ParentId).uuid().not_null())
+                    .col(ColumnDef::new(FileAdjacency::ChildId).uuid().not_null())
+                    .foreign_key(
+                        ForeignKeyCreateStatement::new()
+                            .from_tbl(FileTree::Table)
+                            .from_col(FileTree::Id)
+                            .to_tbl(FileAdjacency::Table)
+                            .to_col(FileAdjacency::TreeId),
+                    )
+                    .foreign_key(
+                        ForeignKeyCreateStatement::new()
+                            .from_tbl(FileNode::Table)
+                            .from_col(FileNode::Id)
+                            .to_tbl(FileAdjacency::Table)
+                            .to_col(FileAdjacency::ParentId),
+                    )
+                    .foreign_key(
+                        ForeignKeyCreateStatement::new()
+                            .from_tbl(FileNode::Table)
+                            .from_col(FileNode::Id)
+                            .to_tbl(FileAdjacency::Table)
+                            .to_col(FileAdjacency::ChildId),
+                    )
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(FileAdjacency::Table).to_owned())
+            .await
+    }
+}
+
+/// Learn more at https://docs.rs/sea-query#iden
+#[derive(Iden)]
+pub enum FileAdjacency {
+    Table,
+    #[iden = "tree_id"]
+    TreeId,
+    #[iden = "parent_id"]
+    ParentId,
+    #[iden = "child_id"]
+    ChildId,
+}

--- a/src-tauri/migration/src/m20220923_134920_file_node.rs
+++ b/src-tauri/migration/src/m20220923_134920_file_node.rs
@@ -9,16 +9,16 @@ impl MigrationTrait for Migration {
         manager
             .create_table(
                 Table::create()
-                    .table(Tree::Table)
+                    .table(FileNode::Table)
                     .if_not_exists()
+                    .col(ColumnDef::new(FileNode::Id).uuid().not_null().primary_key())
                     .col(
-                        ColumnDef::new(Tree::Id)
-                            .uuid()
+                        ColumnDef::new(FileNode::Name)
+                            .text()
                             .not_null()
-                            .primary_key(),
+                            .default("".to_string()),
                     )
-                    .col(ColumnDef::new(Tree::Vertices).json_binary().not_null())
-                    .col(ColumnDef::new(Tree::Adjacency).json_binary().not_null())
+                    .col(ColumnDef::new(FileNode::ElementTreeId).uuid().not_null())
                     .to_owned(),
             )
             .await
@@ -26,16 +26,17 @@ impl MigrationTrait for Migration {
 
     async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
-            .drop_table(Table::drop().table(Tree::Table).to_owned())
+            .drop_table(Table::drop().table(FileNode::Table).to_owned())
             .await
     }
 }
 
 /// Learn more at https://docs.rs/sea-query#iden
 #[derive(Iden)]
-enum Tree {
+pub enum FileNode {
     Table,
     Id,
-    Vertices,
-    Adjacency,
+    Name,
+    #[iden= "element_tree_id"]
+    ElementTreeId,
 }


### PR DESCRIPTION
Best way to store tree/graph in postgres
1. Normalized means memory efficient than jsonb / json
2. Fast writes
3. Reads are slow but we can optimize frontend to use less reads